### PR TITLE
Log numeric version

### DIFF
--- a/src/game/log.ts
+++ b/src/game/log.ts
@@ -33,6 +33,7 @@ export class GameLog {
 
     public complete: boolean = false;
     private version: string = __COMMIT_HASH__;
+    private logVersion: number = 2;
 
     constructor(private gameID: number, private config: GameConfig) {}
 


### PR DESCRIPTION
Started this as I was confused about what 'complete' meant. But figured it's still useful to have a numeric version we can compare against in processing.